### PR TITLE
Fix hash table count in query builder

### DIFF
--- a/modules/__core__/persistent/server/module.lua
+++ b/modules/__core__/persistent/server/module.lua
@@ -115,6 +115,7 @@ Persist = function(schema, pk, ...)
 
     local queryFields = {}
     local keys        = {}
+    local queryFlag   = false
 
     for k,v in pairs(fields) do
       keys[#keys + 1] = v.data.name
@@ -122,11 +123,12 @@ Persist = function(schema, pk, ...)
 
     for k,v in pairs(query) do
       queryFields[fields[k].data.name] = v
+      queryFlag = true
     end
 
     local baseQuery = db.DBQuery().select(keys).from(schema)
 
-    if (#queryFields > 0) then
+    if queryFlag then
       baseQuery = baseQuery.where(queryFields)
     end
 


### PR DESCRIPTION
In Lua you can't count a hash table length with # you have to parse each element or use a flag.