### PR TITLE
Fix management of invalid job in user's data

### DIFF
--- a/modules/__core__/player/server/events.lua
+++ b/modules/__core__/player/server/events.lua
@@ -83,7 +83,7 @@ on('esx:player:load:job', function(identifier, playerId, row, userData, addTask)
       print(('[^3WARNING^7] Ignoring invalid job for %s [job: %s, grade: %s]'):format(identifier, row.job, row.job_grade))
 
       job, grade = 'unemployed', '0'
-      jobObject, gradeObject = ESX.Jobs[row.job], ESX.Jobs[row.job].grades[tostring(row.job_grade)]
+      jobObject, gradeObject = ESX.Jobs[job], ESX.Jobs[job].grades[tostring(grade)]
 
     end
 


### PR DESCRIPTION
Fixes a bug found during feature development, no issue opened atm.

## Given
The user has a not existing job assigned (in the `users` table)

## When
The user tries to join the server: an error is thrown and the user can't join

## Then
Fix applied in `modules/__core__/player/server/events.lua` for proper fallback on default `unemployed` status