### PR TITLE
Changes in config.status.lua

### DIFF
--- a/config/default/config.status.lua
+++ b/config/default/config.status.lua
@@ -2,39 +2,48 @@ Config.Modules.Status = {
   StatusMax          = 100,
   TickTime           = 1000,
   UpdateInterval     = 20,
-  StatusIndex        = {"stress", "drunk", "drugs", "thirst", "hunger"},
   NotificationValues = {0,1,2,3,4,5,6,7,8,9,10,15,20,25,50,75,100},
   DefaultValues      = {0,0,0,100,100},
   StatusInfo         = {
     ["hunger"] = {
+      default  = 100,
       color    = "orange",
       iconType = "fontawesome",
       icon     = "fa-hamburger",
-      fadeType = "desc"
+      fadeType = "desc",
+      NotificationValues = {0,1,2,3,4,5,6,7,8,9,10,15,20,25,50,75,100}
     },
     ["thirst"] = {
+      default  = 100,
       color    = "cyan",
       iconType = "fontawesome",
       icon     = "fa-tint",
-      fadeType = "desc"
+      fadeType = "desc",
+      NotificationValues = {0,1,2,3,4,5,6,7,8,9,10,15,20,25,50,75,100}
     },
     ["drugs"] = {
+      default  = 0,
       color    = "green",
       iconType = "fontawesome",
       icon     = "fa-cannabis",
-      fadeType = "asc"
+      fadeType = "asc",
+      NotificationValues = {0,1,2,3,4,5,6,7,8,9,10,15,20,25,50,75,100}
     },
     ["drunk"] = {
+      default  = 0,
       color    = "purple",
       iconType = "fontawesome",
       icon     = "fa-glass-martini-alt",
-      fadeType = "asc"
+      fadeType = "asc",
+      NotificationValues = {0,1,2,3,4,5,6,7,8,9,10,15,20,25,50,75,100}
     },
     ["stress"] = {
+      default  = 0,
       color    = "pink",
       iconType = "fontawesome",
       icon     = "fa-brain",
-      fadeType = "asc"
+      fadeType = "asc",
+      NotificationValues = {50,75,100}
     }
   }
 }


### PR DESCRIPTION
-Removed StatusIndex since you can get the names from StatusInfo
-Moved DefaultValues to StatusInfo
-Make NotificationValues per status instead of global

Some other change can be the notification system to allow ranges, for example:
the icon of Stress should be seeing at all times if the value is in the range of 50 to 100. Instead of just popping up  in intervals or having to write all the numbers from 50 to 100.