### PR TITLE
chore: introduce .moduleignore

### DIFF
--- a/fxmanifest.tpl.lua
+++ b/fxmanifest.tpl.lua
@@ -26,6 +26,14 @@ dependencies {
   'mysql-async',
 }
 
+ignore {
+    'modules/*/*/data/.moduleignore',
+    'modules/*/*/client/.moduleignore',
+    'modules/*/*/server/.moduleignore',
+    'modules/*/*/shared/.moduleignore',
+    'modules/*/*/.moduleignore'
+}
+
 files {
 
   'data/**/*',

--- a/fxmanifest.workaround.js
+++ b/fxmanifest.workaround.js
@@ -173,8 +173,6 @@ const buildManifest = function (data, ignoredFiles) {
   // .moduleignore
   delete data["ignore"];
 
-  console.log(ignoredFiles);
-
   data.fx_version = data.fx_version || ["bodacious"];
   data.game = data.game || ["gta5"];
 
@@ -235,7 +233,6 @@ const init = () => {
       );
 
       if (entryModuleIgnoresFilesPath.length > 0) {
-        console.log(entryModuleIgnoresFilesPath);
         entryModuleIgnoresFilesPath.map((entryModuleIgnoresFilePath) => {
           const fromRootModuleIgnoreFilePath = path.resolve(
             path.join(root, RESOURCE_NAME, entryModuleIgnoresFilePath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,117 @@
+{
+  "name": "es_extended",
+  "version": "2.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fengari": {
+      "version": "0.1.4",
+      "requires": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fengari-interop": {
+      "version": "0.1.2"
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
+    },
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "fengari": "^0.1.4",
     "fengari-interop": "^0.1.2",
-    "glob": "^7.1.6"
+    "glob": "^7.1.6",
+    "minimatch": "^3.0.4"
   }
 }


### PR DESCRIPTION
Allow to add a .moduleignore inside a module.

The content could be as follow : 
```
node_modules/**/*
public/**/*
src/**/*
.eslintcache
.gitignore
.moduleignore
package.json
README.md
tsconfig.json
yarn.lock
```

Given this module architecture : 

```
+---client
+---data
|   +---build
|   +---node_modules
|   +---public
|   +---src
+---server
+---shared
```

It will ignore all files concerned by the globs declared in .moduleignore (this works like a .gitignore basically)

## Why ?
Because I'm creating a React application into a module and I don't want the manifest to contains all the `node_modules` :)