### PR TITLE
[legacy] Minor change to functions

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -42,6 +42,7 @@ end
 
 ESX.SetPlayerData = function(key, val)
 	ESX.PlayerData[key] = val
+	TriggerEvent('esx:setPlayerData', key, val)
 end
 
 ESX.ShowNotification = function(msg)
@@ -365,10 +366,12 @@ ESX.Game.SpawnVehicle = function(model, coords, heading, cb, networked)
 		ESX.Streaming.RequestModel(model)
 
 		local vehicle = CreateVehicle(model, vector.xyz, heading, networked, false)
-		local id = NetworkGetNetworkIdFromEntity(vehicle)
 
-		SetNetworkIdCanMigrate(id, true)
-		SetEntityAsMissionEntity(vehicle, true, false)
+		if networked then
+			local id = NetworkGetNetworkIdFromEntity(vehicle)
+			SetNetworkIdCanMigrate(id, true)
+			SetEntityAsMissionEntity(vehicle, true, false)
+		end
 		SetVehicleHasBeenOwnedByPlayer(vehicle, true)
 		SetVehicleNeedsToBeHotwired(vehicle, false)
 		SetModelAsNoLongerNeeded(model)
@@ -494,7 +497,8 @@ ESX.Game.GetVehicleInDirection = function()
 	local numRayHandle, hit, endCoords, surfaceNormal, entityHit = GetShapeTestResult(rayHandle)
 
 	if hit == 1 and GetEntityType(entityHit) == 2 then
-		return entityHit
+		local entityCoords = GetEntityCoords(entityHit)
+		return entityHit, entityCoords
 	end
 
 	return nil

--- a/client/main.lua
+++ b/client/main.lua
@@ -121,6 +121,7 @@ AddEventHandler('esx:setAccountMoney', function(account)
 			break
 		end
 	end
+	ESX.SetPlayerData('accounts', ESX.PlayerData.accounts)
 
 	if Config.EnableHud then
 		ESX.UI.HUD.UpdateElement('account_' .. account.name, {

--- a/client/main.lua
+++ b/client/main.lua
@@ -352,7 +352,7 @@ end
 function StartServerSyncLoops()
 	-- keep track of ammo
 	Citizen.CreateThread(function()
-		while true do
+		while ESX.PlayerLoaded do
 			Citizen.Wait(1000)
 
 			local letSleep = true
@@ -379,7 +379,7 @@ function StartServerSyncLoops()
 	Citizen.CreateThread(function()
 		local previousCoords = vector3(ESX.PlayerData.coords.x, ESX.PlayerData.coords.y, ESX.PlayerData.coords.z)
 
-		while true do
+		while ESX.PlayerLoaded do
 			Citizen.Wait(1500)
 			local playerPed = PlayerPedId()
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -73,6 +73,7 @@ ui_page {
 }
 
 files {
+	'imports.lua',
 	'locale.js',
 	'html/ui.html',
 

--- a/imports.lua
+++ b/imports.lua
@@ -1,0 +1,7 @@
+ESX = exports['es_extended']:getSharedObject()
+
+AddEventHandler('esx:setPlayerData', function(key, val)
+	if GetInvokingResource() == 'es_extended' then
+		ESX.PlayerData[key] = val
+	end
+end)


### PR DESCRIPTION
## Proposed Changes
* Add a TriggerEvent to `ESX.SetPlayerData` so we can tell other resources to update
* Only set networked vehicles as persistent and able to migrate
* Return entityCoords from `ESX.Game.GetVehicleInDirection`
* Only run `ServerSyncLoops` while ESX.PlayerLoaded is true
* Create an imports file to set ESX object and EventHandler for `esx:setPlayerData`