### PR TITLE
feat(core/inputs): KeyInput class that wraps RegisterKeyMapping

### DIFF
--- a/modules/__core__/events/shared/module.lua
+++ b/modules/__core__/events/shared/module.lua
@@ -194,17 +194,15 @@ onRequest = function(name, cb)
   module.requestCallbacks[name] = cb
 end
 
---- Base EventEmitter class
----@class EventEmitter
----@field constructor
----@field on
----@field off
+--- @class EventEmitter
+--- @return EventEmitter
 EventEmitter = Extends(nil, 'EventEmitter')
 
 --- Constructor for EventEmitter class
 function EventEmitter:constructor()
   self.handlers = {}
 end
+
 --- Registers an event listener for an event on a EventEmitter
 --- @param name string The name of the event
 --- @param cb function The callback function


### PR DESCRIPTION
This utilizes the much newer and more efficient RegisterKeyMapping native as a means of listening for user input. This does *not* run every frame, making it much more performant.

Also edits documentation for the EventEmitter class so I can extend it in luadocs for the KeyInput class.

### Example:
```lua
local keyInput = KeyInput('k', 'test things', true)

keyInput:onPress(function()
  print('I am pressed yo')
end)

keyInput:onRelease(function()
  print('I am released yo')
end)

local keyInput2 = KeyInput('i', 'test thing 2')

keyInput2:handler(function()
  print('I was pressed yo')
end)
```