### PR TITLE
feat(legacy) ghmattimysql, multicharacter support, minor fixes

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -60,7 +60,7 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 		StartServerSyncLoops()
 	end)
 	if isNew then
-		TriggerEvent('esx_identity:showRegisterIdentity')
+		-- Do stuff here
 	else
 		ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin, jobSkin)
 			TriggerEvent('skinchanger:loadSkin', skin)

--- a/config.lua
+++ b/config.lua
@@ -9,12 +9,13 @@ Config.Accounts = {
 
 Config.StartingAccountMoney 	= {bank = 50000}
 
-Config.EnableSocietyPayouts 	= false -- pay from the society account that the player is employed at? Requirement: esx_society
-Config.EnableHud            	= true -- enable the default hud? Display current job and accounts (black, bank & cash)
-Config.MaxWeight            	= 24   -- the max inventory weight without backpack
-Config.PaycheckInterval         = 7 * 60000 -- how often to recieve pay checks in milliseconds
-Config.EnableDebug              = false -- Use Debug options?
-Config.EnableDefaultInventory   = true -- Display the default Inventory ( F2 )
-Config.EnableWantedLevel    	= false -- Use Normal GTA wanted Level?
-Config.EnablePVP                = true -- Allow Player to player combat
+Config.EnableSocietyPayouts 	= false		-- pay from the society account that the player is employed at? Requirement: esx_society
+Config.EnableHud            	= true		-- enable the default hud? Display current job and accounts (black, bank & cash)
+Config.MaxWeight            	= 24		-- the max inventory weight without backpack
+Config.PaycheckInterval         = 7 * 60000	-- how often to recieve pay checks in milliseconds
+Config.EnableDebug              = false		-- Use Debug options?
+Config.EnableDefaultInventory   = true		-- Display the default Inventory ( F2 )
+Config.EnableWantedLevel    	= false		-- Use Normal GTA wanted Level?
+Config.EnablePVP                = true		-- Allow Player to player combat
 
+Config.Kashacters				= false		-- Enables support for esx_kashacters (requires esx_identity)

--- a/config.lua
+++ b/config.lua
@@ -18,4 +18,7 @@ Config.EnableDefaultInventory   = true		-- Display the default Inventory ( F2 )
 Config.EnableWantedLevel    	= false		-- Use Normal GTA wanted Level?
 Config.EnablePVP                = true		-- Allow Player to player combat
 
-Config.Kashacters				= false		-- Enables support for esx_kashacters (requires esx_identity)
+
+-- ESX Legacy features
+Config.Multichar				= false		-- todo
+Config.UseMySQLAsync 			= true		-- If set to false, remove `@mysql-async/lib/MySQL.lua` from the fxmanifest

--- a/imports.lua
+++ b/imports.lua
@@ -1,8 +1,10 @@
 ESX = exports['es_extended']:getSharedObject()
 
-AddEventHandler('esx:setPlayerData', function(key, val)
-	if GetInvokingResource() == 'es_extended' then
-		ESX.PlayerData[key] = val
-		if OnPlayerData ~= nil then OnPlayerData(key, val) end
-	end
-end)
+if not IsDuplicityVersion() then -- Only register this event for the client
+	AddEventHandler('esx:setPlayerData', function(key, val)
+		if GetInvokingResource() == 'es_extended' then
+			ESX.PlayerData[key] = val
+			if OnPlayerData ~= nil then OnPlayerData(key, val) end
+		end
+	end)
+end

--- a/imports.lua
+++ b/imports.lua
@@ -7,4 +7,18 @@ if not IsDuplicityVersion() then -- Only register this event for the client
 			if OnPlayerData ~= nil then OnPlayerData(key, val) end
 		end
 	end)
+elseif MySQL and not ESX.GetConfig().UseMySQLAsync then
+	Citizen.CreateThread(function()
+		function MySQL.ready(callback)
+			Citizen.CreateThread(function ()
+				while GetResourceState('ghmattimysql') ~= 'started' do
+					Citizen.Wait(0)
+				end
+				MySQL.Async.execute		= function(query, values, cb) exports.ghmattimysql:execute(query, values, cb) end
+				MySQL.Async.fetchAll	= function(query, values, cb) exports.ghmattimysql:execute(query, values, cb) end
+				MySQL.Async.fetchScalar	= function(query, values, cb) exports.ghmattimysql:scalar(query, values, cb) end
+				callback()
+			end)
+		end
+	end)
 end

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -14,7 +14,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.variables = {}
 	self.weight = weight
 	self.maxWeight = Config.MaxWeight
-	if Config.Kashacters then self.license = 'license'..string.sub(identifier, 7) else self.license = 'license'..identifier end
+	if Config.Kashacters then self.license = 'license'..string.sub(identifier, 6) else self.license = 'license:'..identifier end
 
 	ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -14,7 +14,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.variables = {}
 	self.weight = weight
 	self.maxWeight = Config.MaxWeight
-	if Config.Kashacters then self.license = 'license'..string.sub(identifier, 6) else self.license = 'license:'..identifier end
+	if Config.Multichar then self.license = 'license'..string.sub(identifier, 6) else self.license = 'license:'..identifier end
 
 	ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -14,8 +14,9 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.variables = {}
 	self.weight = weight
 	self.maxWeight = Config.MaxWeight
+	if Config.Kashacters then self.license = 'license'..string.sub(identifier, 7) else self.license = 'license'..identifier end
 
-	ExecuteCommand(('add_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+	ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 
 	self.triggerEvent = function(eventName, ...)
 		TriggerClientEvent(eventName, self.source, ...)
@@ -66,9 +67,9 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	self.setGroup = function(newGroup)
-		ExecuteCommand(('remove_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+		ExecuteCommand(('remove_principal identifier.%s group.%s'):format(self.license, self.group))
 		self.group = newGroup
-		ExecuteCommand(('add_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+		ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 	end
 
 	self.getGroup = function()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -229,3 +229,7 @@ ESX.RegisterCommand('players', "admin", function(xPlayer, args, showError)
 		print("^1[ ^2ID : ^5"..xPlayer.source.." ^0| ^2Name : ^5"..xPlayer.getName().." ^0 | ^2Group : ^5"..xPlayer.getGroup().." ^0 | ^2Identifier : ^5".. xPlayer.identifier .."^1]^0\n")
 	end
 end, true)
+
+RegisterCommand('refreshjobs', function(source, args, rawCommand)
+	if source == 0 then RefreshJobs() end
+end, true)

--- a/server/common.lua
+++ b/server/common.lua
@@ -18,7 +18,59 @@ function getSharedObject()
 	return ESX
 end
 
-MySQL.ready(function()
+function Ready(cb)
+	Citizen.CreateThread(function()
+		if Config.UseMySQLAsync then
+			while GetResourceState('mysql-async') ~= 'started' do
+				Citizen.Wait(0)
+			end
+			while not exports['mysql-async']:is_ready() do
+				Citizen.Wait(0)
+			end
+		else
+			if not MySQL then MySQL = { Async = {} } end
+			while GetResourceState('ghmattimysql') ~= 'started' do
+				Citizen.Wait(0)
+			end
+		end
+		cb()
+	end)
+end
+
+function RefreshJobs()
+	MySQL.Async.fetchAll('SELECT * FROM jobs', {}, function(jobs)
+		for k,v in ipairs(jobs) do
+			ESX.Jobs[v.name] = v
+			ESX.Jobs[v.name].grades = {}
+		end
+	
+		MySQL.Async.fetchAll('SELECT * FROM job_grades', {}, function(jobGrades)
+			for k,v in ipairs(jobGrades) do
+				if ESX.Jobs[v.job_name] then
+					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
+				else
+					print(('[^3WARNING^7] Ignoring job grades for ^5"%s"^7^0 due to missing job'):format(v.job_name))
+				end
+			end
+		end)
+	end)
+
+	for k2,v2 in pairs(ESX.Jobs) do
+		if ESX.Table.SizeOf(v2.grades) == 0 then
+			ESX.Jobs[v2.name] = nil
+			print(('[^3WARNING^7] Ignoring job ^5"%s"^7^0due to no job grades found'):format(v2.name))
+		end
+	end
+end
+
+Ready(function()
+
+	if not Config.UseMySQLAsync then -- Patch the functions
+		MySQL.Async.execute		= function(query, values, cb) exports.ghmattimysql:execute(query, values, cb) end
+		MySQL.Async.fetchAll	= function(query, values, cb) exports.ghmattimysql:execute(query, values, cb) end
+		MySQL.Async.fetchScalar	= function(query, values, cb) exports.ghmattimysql:scalar(query, values, cb) end
+	end
+	
 	MySQL.Async.fetchAll('SELECT * FROM items', {}, function(result)
 		for k,v in ipairs(result) do
 			ESX.Items[v.name] = {
@@ -30,37 +82,17 @@ MySQL.ready(function()
 		end
 	end)
 
-	MySQL.Async.fetchAll('SELECT * FROM jobs', {}, function(jobs)
-		for k,v in ipairs(jobs) do
-			ESX.Jobs[v.name] = v
-			ESX.Jobs[v.name].grades = {}
-		end
+	RefreshJobs()
+	ESX.StartDBSync()
+	ESX.StartPayCheck()
 
-		MySQL.Async.fetchAll('SELECT * FROM job_grades', {}, function(jobGrades)
-			for k,v in ipairs(jobGrades) do
-				if ESX.Jobs[v.job_name] then
-					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
-				else
-					print(('[^5es_extended^0] [^3WARNING^7] Ignoring job grades for ^5"%s"^0 due to missing job'):format(v.job_name))
-				end
-			end
-
-			for k2,v2 in pairs(ESX.Jobs) do
-				if ESX.Table.SizeOf(v2.grades) == 0 then
-					ESX.Jobs[v2.name] = nil
-					print(('[^5es_extended^0] [^3WARNING^7] Ignoring job ^5"%s"^0due to no job grades found'):format(v2.name))
-				end
-			end
-		end)
-	end)
-
-	print('[^5es_extended^0] [^2INFO^7] ESX ^5Legacy^0 initialized')
+	print('[^2INFO^7] ESX ^5Legacy^0 initialized')
 end)
 
 RegisterServerEvent('esx:clientLog')
 AddEventHandler('esx:clientLog', function(msg)
 	if Config.EnableDebug then
-		print(('[^5es_extended^0] [^2TRACE^7] %s^7'):format(msg))
+		print(('[^2TRACE^7] %s^7'):format(msg))
 	end
 end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -177,6 +177,7 @@ ESX.SavePlayer = function(xPlayer, cb)
 			['@identifier'] = xPlayer.getIdentifier(),
 			['@inventory'] = json.encode(xPlayer.getInventory(true))
 		}, function(rowsChanged)
+			if not Config.UseMySQLAsync then rowsChanged = rowsChanged.affectedRows end
 			cb2()
 		end)
 	end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,7 +5,7 @@ end)
 
 local awaitingRegistration = {}
 RegisterNetEvent('esx:onPlayerJoined')
-if Config.Kashacters then
+if Config.Multichar then
 	AddEventHandler('esx_identity:completedRegistration', function(playerId, data)
 		awaitingRegistration[playerId] = data
 	end)
@@ -57,7 +57,7 @@ function createESXPlayer(identifier, playerId)
 		defaultGroup = "user"
 	end
 
-	if Config.Kashacters then
+	if Config.Multichar then
 		local data
 		awaitingRegistration[playerId] = true
 		while true do
@@ -265,7 +265,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 		local xPlayer = CreateExtendedPlayer(playerId, identifier, userData.group, userData.accounts, userData.inventory, userData.weight, userData.job, userData.loadout, userData.playerName, userData.coords)
 		ESX.Players[playerId] = xPlayer
 
-		if Config.Kashacters and userData.firstname then 
+		if Config.Multichar and userData.firstname then 
 			xPlayer.set('firstName', userData.firstname)
 			xPlayer.set('lastName', userData.lastname)
 			if userData.dateofbirth then xPlayer.set('dateofbirth', userData.dateofbirth) end
@@ -315,7 +315,7 @@ AddEventHandler('playerDropped', function(reason)
 	end
 end)
 
-if Config.Kashacters then -- Still experimental
+if Config.Multichar then -- Still experimental
 	RegisterCommand('relog', function(source, args, rawCommand)
 		TriggerEvent('esx:playerLogout', source)
 	end, true)

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,51 +3,88 @@ Citizen.CreateThread(function()
 	SetGameType('ESX Roleplay')
 end)
 
+local awaitingRegistration = {}
 RegisterNetEvent('esx:onPlayerJoined')
-AddEventHandler('esx:onPlayerJoined', function()
-	if not ESX.Players[source] then
-		onPlayerJoined(source)
-	end
-end)
+if Config.Kashacters then
+	AddEventHandler('esx_identity:completedRegistration', function(playerId, data)
+		awaitingRegistration[playerId] = data
+	end)
+	AddEventHandler('esx:onPlayerJoined', function(src, slot, isNew)
+		if not ESX.Players[src] then
+			onPlayerJoined(src, slot)
+		end
+	end)
+else
+	AddEventHandler('esx:onPlayerJoined', function()
+		if not ESX.Players[source] then
+			onPlayerJoined(source)
+		end
+	end)
+end
 
-function onPlayerJoined(playerId)
+function onPlayerJoined(playerId, slot, isNew)
 	local identifier = ESX.GetIdentifier(playerId)
+	if slot then identifier = 'char'..slot..':'..identifier end
 
 	if identifier then
 		if ESX.GetPlayerFromIdentifier(identifier) then
 			DropPlayer(playerId, ('there was an error loading your character!\nError code: identifier-active-ingame\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same Rockstar account.\n\nYour Rockstar identifier: %s'):format(identifier))
-		else
+		elseif isNew ~= true then
 			MySQL.Async.fetchScalar('SELECT 1 FROM users WHERE identifier = @identifier', {
 				['@identifier'] = identifier
 			}, function(result)
 				if result then
 					loadESXPlayer(identifier, playerId, false)
-				else
-					local accounts = {}
-
-					for account,money in pairs(Config.StartingAccountMoney) do
-						accounts[account] = money
-					end
-
-					if IsPlayerAceAllowed(playerId, "command") then
-						print(('[^5es_extended^0] ^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
-						defaultGroup = "admin"
-					else
-						defaultGroup = "user"
-					end
-
-					MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`) VALUES (@accounts, @identifier, @group)', {
-						['@accounts'] = json.encode(accounts),
-						['@identifier'] = identifier,
-						['@group'] = defaultGroup
-					}, function(rowsChanged)
-						loadESXPlayer(identifier, playerId, true)
-					end)
-				end
+				else createESXPlayer(identifier, playerId) end
 			end)
-		end
+		else createESXPlayer(identifier, playerId) end
 	else
 		DropPlayer(playerId, 'there was an error loading your character!\nError code: identifier-missing-ingame\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.')
+	end
+end
+
+function createESXPlayer(identifier, playerId)
+	local accounts = {}
+
+	for account,money in pairs(Config.StartingAccountMoney) do
+		accounts[account] = money
+	end
+
+	if IsPlayerAceAllowed(playerId, "command") then
+		print(('^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
+		defaultGroup = "admin"
+	else
+		defaultGroup = "user"
+	end
+
+	if Config.Kashacters then
+		local data
+		awaitingRegistration[playerId] = true
+		while true do
+			Citizen.Wait(250)
+			if awaitingRegistration[playerId] ~= true then data = awaitingRegistration[playerId] break end
+		end
+		awaitingRegistration[playerId] = nil
+		MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height`) VALUES (@accounts, @identifier, @group, @firstname, @lastname, @dateofbirth, @sex, @height)', {
+			['@accounts'] = json.encode(accounts),
+			['@identifier'] = identifier,
+			['@group'] = defaultGroup,
+			['@firstname'] = data.firstname,
+			['@lastname'] = data.lastname,
+			['@dateofbirth'] = data.dateofbirth,
+			['@sex'] = data.sex,
+			['@height'] = data.height,
+		}, function(rowsChanged)
+			loadESXPlayer(identifier, playerId, true)
+		end)
+	else
+		MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`) VALUES (@accounts, @identifier, @group)', {
+			['@accounts'] = json.encode(accounts),
+			['@identifier'] = identifier,
+			['@group'] = defaultGroup
+		}, function(rowsChanged)
+			loadESXPlayer(identifier, playerId, true)
+		end)
 	end
 end
 
@@ -81,7 +118,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 	}
 
 	table.insert(tasks, function(cb)
-		MySQL.Async.fetchAll('SELECT accounts, job, job_grade, `group`, loadout, position, inventory FROM users WHERE identifier = @identifier', {
+		MySQL.Async.fetchAll('SELECT * FROM users WHERE identifier = @identifier', {
 			['@identifier'] = identifier
 		}, function(result)
 			local job, grade, jobObject, gradeObject = result[1].job, tostring(result[1].job_grade)
@@ -203,6 +240,23 @@ function loadESXPlayer(identifier, playerId, isNew)
 				userData.coords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
 			end
 
+			-- Skin
+			if result[1].skin and result[1].skin ~= '' then
+				userData.skin = json.decode(result[1].skin)
+			elseif result[1].sex then
+				if result[1].sex == 'f' then userData.skin = {sex = 1} else userData.skin = {sex = 0} end
+			end
+
+			-- Identity
+			if result[1].firstname and result[1].firstname ~= '' then
+				userData.firstname = result[1].firstname
+				userData.lastname = result[1].lastname
+				userData.playerName = userData.firstname..' '..userData.lastname
+				if result[1].dateofbirth then userData.dateofbirth = result[1].dateofbirth end
+				if result[1].sex then userData.sex = result[1].sex end
+				if result[1].height then userData.height = result[1].height end
+			end
+
 			cb()
 		end)
 	end)
@@ -210,6 +264,15 @@ function loadESXPlayer(identifier, playerId, isNew)
 	Async.parallel(tasks, function(results)
 		local xPlayer = CreateExtendedPlayer(playerId, identifier, userData.group, userData.accounts, userData.inventory, userData.weight, userData.job, userData.loadout, userData.playerName, userData.coords)
 		ESX.Players[playerId] = xPlayer
+
+		if Config.Kashacters and userData.firstname then 
+			xPlayer.set('firstName', userData.firstname)
+			xPlayer.set('lastName', userData.lastname)
+			if userData.dateofbirth then xPlayer.set('dateofbirth', userData.dateofbirth) end
+			if userData.sex then xPlayer.set('sex', userData.sex) end
+			if userData.height then xPlayer.set('height', userData.height) end
+		end
+		
 		TriggerEvent('esx:playerLoaded', playerId, xPlayer, isNew)
 
 		xPlayer.triggerEvent('esx:playerLoaded', {
@@ -220,7 +283,8 @@ function loadESXPlayer(identifier, playerId, isNew)
 			job = xPlayer.getJob(),
 			loadout = xPlayer.getLoadout(),
 			maxWeight = xPlayer.getMaxWeight(),
-			money = xPlayer.getMoney()
+			money = xPlayer.getMoney(),
+			skin = userData.skin
 		}, isNew)
 
 		xPlayer.triggerEvent('esx:createMissingPickups', ESX.Pickups)
@@ -240,6 +304,7 @@ end)
 AddEventHandler('playerDropped', function(reason)
 	local playerId = source
 	local xPlayer = ESX.GetPlayerFromId(playerId)
+	awaitingRegistration[playerId] = nil
 
 	if xPlayer then
 		TriggerEvent('esx:playerDropped', playerId, reason)
@@ -249,6 +314,25 @@ AddEventHandler('playerDropped', function(reason)
 		end)
 	end
 end)
+
+if Config.Kashacters then -- Still experimental
+	RegisterCommand('relog', function(source, args, rawCommand)
+		TriggerEvent('esx:playerLogout', source)
+	end, true)
+
+	AddEventHandler('esx:playerLogout', function(playerId)
+		local xPlayer = ESX.GetPlayerFromId(playerId)
+		awaitingRegistration[playerId] = nil
+		if xPlayer then
+			TriggerEvent('esx:playerDropped', playerId, reason)
+
+			ESX.SavePlayer(xPlayer, function()
+				ESX.Players[playerId] = nil
+			end)
+		end
+		TriggerClientEvent("esx:onPlayerLogout", playerId)
+	end)
+end
 
 RegisterNetEvent('esx:updateCoords')
 AddEventHandler('esx:updateCoords', function(coords)


### PR DESCRIPTION
### Fixes and changes
* Remove identity registration trigger when character is new
* Set `ESX.PlayerData` for `ped` and `dead`
* Only register the `esx:setPlayerData` event for clients
* Allow refreshing of jobs with `refreshjobs` command in the console


### ghmattimysql support (unfinished)
* Patch the MySQL.Async function calls to trigger ghmattimysql instead when enabled by config
* ~~Attempt to patch the functions in other resources by using the import~~ Would require importing MySQL before the ESX import from what I can tell - any way we can import the server_script from outside fxmanifest?
Need to patch more functions (or maybe just scrap it?)


### Multicharacter support (unfinished)
* Prepared events and functions
* Store identifier and license separately (where identifier would be `char1:license`)
Pending response from KASH or new multicharacter
