### PR TITLE
fix(core/account): Add/remove fields of accounts of previous players + cleanup

### DIFF
--- a/config/default/config.account.lua
+++ b/config/default/config.account.lua
@@ -1,4 +1,0 @@
-Config.Modules.Account = {
-  AccountsIndex        = {"wallet", "fleeca", "maze"},
-  DefaultValues        = {0,0,0}
-}

--- a/modules/__core__/account/server/module.lua
+++ b/modules/__core__/account/server/module.lua
@@ -15,7 +15,27 @@ M('serializable')
 
 Account = Extends(Serializable, 'Account')
 
-function Account:constructor(data)
+function Account:constructor(data, defaultFields)
+
+  if defaultFields then
+
+    for k,v in pairs(defaultFields) do
+
+      if data[k] == nil then
+        data[k] = v
+      end
+
+    end
+
+    for k,_ in pairs(data) do
+
+      if defaultFields[k] == nil then
+        data[k] = nil
+      end
+
+    end
+
+  end
 
   self.super:ctor(data)
 

--- a/modules/__core__/identity/server/module.lua
+++ b/modules/__core__/identity/server/module.lua
@@ -78,7 +78,7 @@ function Identity.loadForPlayer(identity, player)
   Identity.all[identityId] = identity
 
   -- Construct account from serialized account
-  identity:field('accounts', Account(identity:getAccounts()))
+  identity:field('accounts', Account(identity:getAccounts(), accounts))
 
   player:setIdentityId(identity:getId())
   player:field('identity', identity)


### PR DESCRIPTION
## Proposed Changes

    - When a player joins verify if his account has the same fields of the default one. If not, add/remove the corresponding fields.
    - Removed config.account.lua, since it is not used it anymore.
