### PR TITLE
feat+improvements(legacy): Multicharacter support; bug fixes and optimisation; retrieve player identity and death status on load

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -42,7 +42,9 @@ end
 
 ESX.SetPlayerData = function(key, val)
 	ESX.PlayerData[key] = val
-	TriggerEvent('esx:setPlayerData', key, val)
+	if key ~= 'inventory' and key ~= 'loadout' then
+		TriggerEvent('esx:setPlayerData', key, val)
+	end
 end
 
 ESX.ShowNotification = function(msg)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -141,6 +141,16 @@ ESX.UI.HUD.RemoveElement = function(name)
 	})
 end
 
+ESX.UI.HUD.Reset = function()
+	for i=1, #ESX.UI.HUD.RegisteredElements, 1 do
+		SendNUIMessage({
+			action    = 'deleteHUDElement',
+			name      = ESX.UI.HUD.RegisteredElements[i]
+		})
+	end
+	ESX.UI.HUD.RegisteredElements = {}
+end
+
 ESX.UI.HUD.UpdateElement = function(name, data)
 	SendNUIMessage({
 		action = 'updateHUDElement',

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -324,7 +324,7 @@ ESX.Game.Teleport = function(entity, coords, cb)
 	if DoesEntityExist(entity) then
 		RequestCollisionAtCoord(vector.xyz)
 		while not HasCollisionLoadedAroundEntity(entity) do
-			Wait(0)
+			Citizen.Wait(0)
 		end
 
 		SetEntityCoords(entity, vector.xyz, false, false, false, false)
@@ -342,7 +342,7 @@ ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
 	networked = networked == nil and true or false
 	dynamic = dynamic ~= nil and true or false
 
-	CreateThread(function()
+	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 
 		-- The below has to be done just for CreateObject since for some reason CreateObjects model argument is set
@@ -374,7 +374,7 @@ ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 	networked = networked == nil and true or false
-	CreateThread(function()
+	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 
 		local vehicle = CreateVehicle(model, vector.xyz, heading, networked, false)
@@ -391,7 +391,7 @@ ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 
 		RequestCollisionAtCoord(vector.xyz)
 		while not HasCollisionLoadedAroundEntity(vehicle) do
-			Wait(0)
+			Citizen.Wait(0)
 		end
 
 		if cb then

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -729,7 +729,8 @@ ESX.Game.Utils.DrawText3D = function(coords, text, size, font)
 	SetDrawOrigin(vector.xyz, 0)
 	DrawText(0.0, 0.0)
 	local scaleFactor = scale * fov
-	DrawRect(0.0, 0.01 * scaleFactor, (string.len(text) / 220) * scaleFactor, 0.02 * scaleFactor, 0, 0, 0, 75)
+	local length = string.len(string.gsub(text, "(~[rbgypcmuosh]~)", ""))
+	DrawRect(0.0, 0.0 + 0.0111 * scaleFactor, 0.027 + (length / 260) * scaleFactor, 0.03 * scaleFactor, 0, 0, 0, 75)
 	ClearDrawOrigin()
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -709,13 +709,20 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 	end
 end
 
-ESX.Game.Utils.DrawText3D = function(coords, text, scale, font)
+ESX.Game.Utils.DrawText3D = function(coords, text, size, font)
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 
-	if not scale then scale = 0.35 end
-	if not font then font = 4 end
+	local camCoords = GetGameplayCamCoords()
+	local distance = #(vector - camCoords)
 
-	SetTextScale(scale, scale)
+	if not size then size = 1 end
+	if not font then font = 0 end
+
+	local scale = (size / distance) * 2
+	local fov = (1 / GetGameplayCamFov()) * 100
+	scale = scale * fov
+
+	SetTextScale(0.0 * scale, 0.55 * scale)
 	SetTextFont(font)
 	SetTextProportional(1)
 	SetTextColour(255, 255, 255, 215)
@@ -724,8 +731,8 @@ ESX.Game.Utils.DrawText3D = function(coords, text, scale, font)
 	AddTextComponentString(text)
 	SetDrawOrigin(vector.xyz, 0)
 	DrawText(0.0, 0.0)
-	local scaleFactor = scale / 0.35
-	DrawRect(0.0, 0.0 + 0.0111 * scaleFactor, 0.017 + (string.len(text) / 370) * scaleFactor, 0.03 * scaleFactor, 0, 0, 0, 75)
+	local scaleFactor = scale * fov
+	DrawRect(0.0, 0.01 * scaleFactor, (string.len(text) / 220) * scaleFactor, 0.02 * scaleFactor, 0, 0, 0, 75)
 	ClearDrawOrigin()
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -706,7 +706,7 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 	end
 end
 
-ESX.Game.Utils.DrawText3D = function(coords, text, size, font, rect)
+ESX.Game.Utils.DrawText3D = function(coords, text, size, font)
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 
 	local camCoords = GetGameplayCamCoords()
@@ -728,10 +728,6 @@ ESX.Game.Utils.DrawText3D = function(coords, text, size, font, rect)
 	AddTextComponentString(text)
 	SetDrawOrigin(vector.xyz, 0)
 	DrawText(0.0, 0.0)
-	if rect then
-		local length = string.len(text:gsub('~.-~', ''))/13.5
-		DrawRect(0.0, 0.18 / distance, length / distance, 0.04 * scale , 0,0,0, 75)
-	end
 	ClearDrawOrigin()
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -142,12 +142,9 @@ ESX.UI.HUD.RemoveElement = function(name)
 end
 
 ESX.UI.HUD.Reset = function()
-	for i=1, #ESX.UI.HUD.RegisteredElements, 1 do
-		SendNUIMessage({
-			action    = 'deleteHUDElement',
-			name      = ESX.UI.HUD.RegisteredElements[i]
-		})
-	end
+	SendNUIMessage({
+		action    = 'resetHUDElements'
+	})
 	ESX.UI.HUD.RegisteredElements = {}
 end
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -706,7 +706,7 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 	end
 end
 
-ESX.Game.Utils.DrawText3D = function(coords, text, size, font)
+ESX.Game.Utils.DrawText3D = function(coords, text, size, font, rect)
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 
 	local camCoords = GetGameplayCamCoords()
@@ -728,9 +728,10 @@ ESX.Game.Utils.DrawText3D = function(coords, text, size, font)
 	AddTextComponentString(text)
 	SetDrawOrigin(vector.xyz, 0)
 	DrawText(0.0, 0.0)
-	local scaleFactor = scale * fov
-	local length = string.len(string.gsub(text, "(~[rbgypcmuosh]~)", ""))
-	DrawRect(0.0, 0.0 + 0.0111 * scaleFactor, 0.027 + (length / 260) * scaleFactor, 0.03 * scaleFactor, 0, 0, 0, 75)
+	if rect then
+		local length = string.len(text:gsub('~.-~', ''))/13.5
+		DrawRect(0.0, 0.18 / distance, length / distance, 0.04 * scale , 0,0,0, 75)
+	end
 	ClearDrawOrigin()
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -371,10 +371,17 @@ end
 function StartServerSyncLoops()
 	-- keep track of ammo
 	Citizen.CreateThread(function()
+		local currentWeapon = {timer=0}
 		while ESX.PlayerLoaded do
-			Citizen.Wait(1000)
+			local sleep = 5
 
-			local letSleep = true
+			if currentWeapon.timer == sleep then
+				local ammoCount = GetAmmoInPedWeapon(ESX.PlayerData.ped, currentWeapon.hash)
+				TriggerServerEvent('esx:updateWeaponAmmo', currentWeapon.name, ammoCount)
+				currentWeapon.timer = 0
+			elseif currentWeapon.timer > sleep then
+				currentWeapon.timer = currentWeapon.timer - sleep
+			end
 
 			if IsPedArmed(ESX.PlayerData.ped, 4) then
 				if IsPedShooting(ESX.PlayerData.ped) then
@@ -382,14 +389,15 @@ function StartServerSyncLoops()
 					local weapon = ESX.GetWeaponFromHash(weaponHash)
 
 					if weapon then
-						local ammoCount = GetAmmoInPedWeapon(ESX.PlayerData.ped, weaponHash)
-						TriggerServerEvent('esx:updateWeaponAmmo', weapon.name, ammoCount)
+						currentWeapon.name = weapon.name
+						currentWeapon.hash = weaponHash	
+						currentWeapon.timer = 100 * sleep		
 					end
 				end
+			else
+				sleep = 200
 			end
-			if letSleep then
-				Citizen.Wait(500)
-			end
+			Citizen.Wait(sleep)
 		end
 	end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -9,12 +9,12 @@ Citizen.CreateThread(function()
 	end
 end)
 
-
+fix(client/main): Set PlayerData.ped correctly
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 	ESX.PlayerLoaded = true
 	ESX.PlayerData = playerData
-	ESX.PlayerData.ped = ESX.PlayerData.ped
+	ESX.PlayerData.ped = PlayerPedId()
 
 	FreezeEntityPosition(ESX.PlayerData.ped, true)
 	

--- a/client/main.lua
+++ b/client/main.lua
@@ -43,8 +43,8 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 	end
 
 	if Config.Multichar then
-		TriggerEvent('esx_multicharacter:SpawnCharacter', playerData.coords, isNew, playerData.skin)
-		Citizen.Wait(4000)
+		TriggerEvent('esx_multicharacter:SpawnCharacter', playerData.coords, isNew)
+		Citizen.Wait(3000)
 	else
 		exports.spawnmanager:spawnPlayer({
 			x = playerData.coords.x,
@@ -52,25 +52,21 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 			z = playerData.coords.z + 0.25,
 			heading = playerData.coords.heading,
 			model = `mp_m_freemode_01`,
-			skipFade = true
+			skipFade = false
 		}, function()
 			TriggerEvent('esx:onPlayerSpawn')
 			TriggerEvent('playerSpawned') -- compatibility with old scripts
 			TriggerEvent('esx:restoreLoadout')
+			if isNew then
+				if playerData.skin.sex == 0 then
+					TriggerEvent('skinchanger:loadDefaultModel', true)
+				else
+					TriggerEvent('skinchanger:loadDefaultModel', false)
+				end
+			elseif playerData.skin then TriggerEvent('skinchanger:loadSkin', playerData.skin) end
+			TriggerEvent('esx:loadingScreenOff')
+			FreezeEntityPosition(ESX.PlayerData.ped, false)
 		end)
-		Citizen.Wait(1000)
-		if isNew then
-			if playerData.skin.sex == 0 then
-				TriggerEvent('skinchanger:loadDefaultModel', true)
-			else
-				TriggerEvent('skinchanger:loadDefaultModel', false)
-			end
-		elseif playerData.skin then TriggerEvent('skinchanger:loadSkin', playerData.skin) end
-		ShutdownLoadingScreen()
-		ShutdownLoadingScreenNui()
-		TriggerEvent('esx:loadingScreenOff')
-		DoScreenFadeIn(500)
-		FreezeEntityPosition(ESX.PlayerData.ped, false)
 	end
 	StartServerSyncLoops()
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,4 +1,4 @@
-local isPaused, isDead, pickups = false, false, {}
+local pickups = {}
 
 Citizen.CreateThread(function()
 	while NetworkIsPlayerActive(PlayerId()) and not Config.Multichar do
@@ -84,14 +84,12 @@ AddEventHandler('esx:onPlayerSpawn', function()
 	local playerPed = PlayerPedId()
 	if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
 	ESX.SetPlayerData('dead', false)
-	isDead = false
 end)
 
 AddEventHandler('esx:onPlayerDeath', function()
 	local playerPed = PlayerPedId()
 	if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
 	ESX.SetPlayerData('dead', true)
-	isDead = true
 end)
 
 AddEventHandler('skinchanger:modelLoaded', function()
@@ -349,6 +347,7 @@ end)
 -- Pause menu disables HUD display
 if Config.EnableHud then
 	Citizen.CreateThread(function()
+		local isPaused = false
 		while true do
 			Citizen.Wait(300)
 
@@ -418,7 +417,7 @@ end
 
 if Config.EnableDefaultInventory then
 	RegisterCommand('showinv', function()
-		if not isDead and not ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
+		if not ESX.PlayerData.dead and not ESX.UI.Menu.IsOpen('default', 'es_extended', 'inventory') then
 			ESX.ShowInventory()
 		end
 	end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,7 +3,7 @@ local isPaused, isDead, pickups = false, false, {}
 Citizen.CreateThread(function()
 	while NetworkIsPlayerActive(PlayerId()) and not Config.Multichar do
 		Citizen.Wait(5)
-		DoScreenFadeOut(500)
+		DoScreenFadeOut(0)
 		TriggerServerEvent('esx:onPlayerJoined')
 		break
 	end

--- a/client/main.lua
+++ b/client/main.lua
@@ -16,7 +16,6 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 	ESX.PlayerData = playerData
 	ESX.PlayerData.ped = ESX.PlayerData.ped
 
-
 	FreezeEntityPosition(ESX.PlayerData.ped, true)
 	
 	-- enable PVP
@@ -79,6 +78,7 @@ end)
 RegisterNetEvent('esx:onPlayerLogout')
 AddEventHandler('esx:onPlayerLogout', function()
 	ESX.PlayerLoaded = false
+	if Config.EnableHud then ESX.UI.HUD.Reset() end
 end)
 
 RegisterNetEvent('esx:setMaxWeight')

--- a/client/main.lua
+++ b/client/main.lua
@@ -54,6 +54,7 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 			model = `mp_m_freemode_01`,
 			skipFade = false
 		}, function()
+			TriggerServerEvent('esx:onPlayerSpawn')
 			TriggerEvent('esx:onPlayerSpawn')
 			TriggerEvent('playerSpawned') -- compatibility with old scripts
 			TriggerEvent('esx:restoreLoadout')
@@ -65,6 +66,8 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 				end
 			elseif playerData.skin then TriggerEvent('skinchanger:loadSkin', playerData.skin) end
 			TriggerEvent('esx:loadingScreenOff')
+			ShutdownLoadingScreen()
+			ShutdownLoadingScreenNui()
 			FreezeEntityPosition(ESX.PlayerData.ped, false)
 		end)
 	end

--- a/client/main.lua
+++ b/client/main.lua
@@ -10,7 +10,7 @@ Citizen.CreateThread(function()
 end)
 
 RegisterNetEvent('esx:playerLoaded')
-AddEventHandler('esx:playerLoaded', function(playerData, isNew)
+AddEventHandler('esx:playerLoaded', function(playerData, isNew, skin)
 	ESX.PlayerLoaded = true
 	ESX.PlayerData = playerData
 
@@ -33,12 +33,12 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 			TriggerEvent('playerSpawned') -- compatibility with old scripts
 			TriggerEvent('esx:restoreLoadout')
 			if isNew then
-				if playerData.skin.sex == 0 then
+				if skin.sex == 0 then
 					TriggerEvent('skinchanger:loadDefaultModel', true)
 				else
 					TriggerEvent('skinchanger:loadDefaultModel', false)
 				end
-			elseif playerData.skin then TriggerEvent('skinchanger:loadSkin', playerData.skin) end
+			elseif skin then TriggerEvent('skinchanger:loadSkin', skin) end
 			TriggerEvent('esx:loadingScreenOff')
 			ShutdownLoadingScreen()
 			ShutdownLoadingScreenNui()

--- a/client/main.lua
+++ b/client/main.lua
@@ -9,38 +9,12 @@ Citizen.CreateThread(function()
 	end
 end)
 
-fix(client/main): Set PlayerData.ped correctly
 RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 	ESX.PlayerLoaded = true
 	ESX.PlayerData = playerData
-	ESX.PlayerData.ped = PlayerPedId()
 
-	FreezeEntityPosition(ESX.PlayerData.ped, true)
-	
-	-- enable PVP
-	if Config.EnablePVP then
-		SetCanAttackFriendly(ESX.PlayerData.ped, true, false)
-		NetworkSetFriendlyFireOption(true)
-	end
-
-	if Config.EnableHud then
-		for k,v in ipairs(playerData.accounts) do
-			local accountTpl = '<div><img src="img/accounts/' .. v.name .. '.png"/>&nbsp;{{money}}</div>'
-			ESX.UI.HUD.RegisterElement('account_' .. v.name, k, 0, accountTpl, {money = ESX.Math.GroupDigits(v.money)})
-		end
-
-		local jobTpl = '<div>{{job_label}} - {{grade_label}}</div>'
-
-		if playerData.job.grade_label == '' or playerData.job.grade_label == playerData.job.label then
-			jobTpl = '<div>{{job_label}}</div>'
-		end
-
-		ESX.UI.HUD.RegisterElement('job', #playerData.accounts, 0, jobTpl, {
-			job_label = playerData.job.label,
-			grade_label = playerData.job.grade_label
-		})
-	end
+	FreezeEntityPosition(PlayerPedId(), true)
 
 	if Config.Multichar then
 		TriggerEvent('esx_multicharacter:SpawnCharacter', playerData.coords, isNew)
@@ -70,6 +44,31 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew)
 			ShutdownLoadingScreenNui()
 			FreezeEntityPosition(ESX.PlayerData.ped, false)
 		end)
+	end
+
+	while ESX.PlayerData.ped == nil do Citizen.Wait(20) end
+	-- enable PVP
+	if Config.EnablePVP then
+		SetCanAttackFriendly(ESX.PlayerData.ped, true, false)
+		NetworkSetFriendlyFireOption(true)
+	end
+
+	if Config.EnableHud then
+		for k,v in ipairs(playerData.accounts) do
+			local accountTpl = '<div><img src="img/accounts/' .. v.name .. '.png"/>&nbsp;{{money}}</div>'
+			ESX.UI.HUD.RegisterElement('account_' .. v.name, k, 0, accountTpl, {money = ESX.Math.GroupDigits(v.money)})
+		end
+
+		local jobTpl = '<div>{{job_label}} - {{grade_label}}</div>'
+
+		if playerData.job.grade_label == '' or playerData.job.grade_label == playerData.job.label then
+			jobTpl = '<div>{{job_label}}</div>'
+		end
+
+		ESX.UI.HUD.RegisterElement('job', #playerData.accounts, 0, jobTpl, {
+			job_label = playerData.job.label,
+			grade_label = playerData.job.grade_label
+		})
 	end
 	StartServerSyncLoops()
 end)

--- a/config.lua
+++ b/config.lua
@@ -18,4 +18,5 @@ Config.EnableDefaultInventory   = true -- Display the default Inventory ( F2 )
 Config.EnableWantedLevel    	= false -- Use Normal GTA wanted Level?
 Config.EnablePVP                = true -- Allow Player to player combat
 
-Config.Multichar				= false -- Requires esx_multicharacter
+Config.Multichar                = false -- Enable support for esx_multicharacter
+Config.Identity                 = true -- Select a characters identity data before they have loaded in (this happens by default with multichar)

--- a/config.lua
+++ b/config.lua
@@ -18,3 +18,4 @@ Config.EnableDefaultInventory   = true -- Display the default Inventory ( F2 )
 Config.EnableWantedLevel    	= false -- Use Normal GTA wanted Level?
 Config.EnablePVP                = true -- Allow Player to player combat
 
+Config.Multichar				= true -- Requires esx_multicharacter

--- a/config.lua
+++ b/config.lua
@@ -18,4 +18,4 @@ Config.EnableDefaultInventory   = true -- Display the default Inventory ( F2 )
 Config.EnableWantedLevel    	= false -- Use Normal GTA wanted Level?
 Config.EnablePVP                = true -- Allow Player to player combat
 
-Config.Multichar				= true -- Requires esx_multicharacter
+Config.Multichar				= false -- Requires esx_multicharacter

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -101,5 +101,6 @@ server_exports {
 
 dependencies {
 	'mysql-async',
-	'async'
+	'async',
+	'spawnmanager',
 }

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -41,6 +41,11 @@
 		ESX.refreshHUD();
 	};
 
+	ESX.resetHUDElements = function () {
+		ESX.HUDElements = [];
+		ESX.refreshHUD();
+	};
+
 	ESX.refreshHUD = function () {
 		$('#hud').html('');
 
@@ -92,6 +97,11 @@
 
 			case 'deleteHUDElement': {
 				ESX.deleteHUDElement(data.name);
+				break;
+			}
+
+			case 'resetHUDElements': {
+				ESX.resetHUDElements();
 				break;
 			}
 

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -14,8 +14,9 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.variables = {}
 	self.weight = weight
 	self.maxWeight = Config.MaxWeight
+	if Config.Multichar then self.license = 'license'..string.sub(identifier, 6) else self.license = 'license:'..identifier end
 
-	ExecuteCommand(('add_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+	ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 
 	self.triggerEvent = function(eventName, ...)
 		TriggerClientEvent(eventName, self.source, ...)
@@ -66,9 +67,9 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	self.setGroup = function(newGroup)
-		ExecuteCommand(('remove_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+		ExecuteCommand(('remove_principal identifier.%s group.%s'):format(self.license, self.group))
 		self.group = newGroup
-		ExecuteCommand(('add_principal identifier.license:%s group.%s'):format(self.identifier, self.group))
+		ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.license, self.group))
 	end
 
 	self.getGroup = function()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -118,7 +118,7 @@ end, true, {help = _U('command_clearinventory'), validate = true, arguments = {
 
 ESX.RegisterCommand('clearloadout', 'admin', function(xPlayer, args, showError)
 	for i=#args.playerId.loadout, 1, -1 do
-		xPlayer.removeWeapon(args.playerId.loadout[i].name)
+		args.playerId.removeWeapon(args.playerId.loadout[i].name)
 	end
 end, true, {help = _U('command_clearloadout'), validate = true, arguments = {
 	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -161,17 +161,6 @@ ESX.RegisterCommand('coords', "admin", function(xPlayer, args, showError)
 	print("".. xPlayer.getName().. ": ^5".. xPlayer.getCoords(true))
 end, true)
 
-ESX.RegisterCommand('sv_restart', "admin", function(xPlayer, args, showError)
-	Citizen.CreateThread(function()
-		ESX.SavePlayers()
-		for _, playerId in ipairs(GetPlayers()) do
-			DropPlayer(playerId, "Server Restart")
-		end
-		print('^2[INFO] ^1 Server Restarting, Please Wait :)')
-		while true do end
-	end)
-end, true)
-
 ESX.RegisterCommand('tpm', "admin", function(xPlayer, args, showError)
 	xPlayer.triggerEvent("esx:tpm")
 end, true)

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -117,8 +117,8 @@ end, true, {help = _U('command_clearinventory'), validate = true, arguments = {
 }})
 
 ESX.RegisterCommand('clearloadout', 'admin', function(xPlayer, args, showError)
-	for k,v in ipairs(args.playerId.loadout) do
-		args.playerId.removeWeapon(v.name)
+	for i=#args.playerId.loadout, 1, -1 do
+		xPlayer.removeWeapon(args.playerId.loadout[i].name)
 	end
 end, true, {help = _U('command_clearloadout'), validate = true, arguments = {
 	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -1,4 +1,3 @@
-local crash = false
 ESX.RegisterCommand('setcoords', 'admin', function(xPlayer, args, showError)
 	xPlayer.setCoords({x = args.x, y = args.y, z = args.z})
 end, false, {help = _U('command_setcoords'), validate = true, arguments = {
@@ -169,9 +168,7 @@ ESX.RegisterCommand('sv_restart', "admin", function(xPlayer, args, showError)
 			DropPlayer(playerId, "Server Restart")
 		end
 		print('^2[INFO] ^1 Server Restarting, Please Wait :)')
-		crash = true
-		while crash do
-		end
+		while true do end
 	end)
 end, true)
 

--- a/server/common.lua
+++ b/server/common.lua
@@ -46,7 +46,7 @@ MySQL.ready(function()
 				end
 			end
 
-			for k2,v2 in pairs(ESX.Jobs) do
+			for k2,v2 in pairs(Jobs) do
 				if ESX.Table.SizeOf(v2.grades) == 0 then
 					Jobs[v2.name] = nil
 					print(('[^3WARNING^7] Ignoring job ^5"%s"^0due to no job grades found'):format(v2.name))

--- a/server/common.lua
+++ b/server/common.lua
@@ -30,16 +30,17 @@ MySQL.ready(function()
 		end
 	end)
 
+	local Jobs = {}
 	MySQL.Async.fetchAll('SELECT * FROM jobs', {}, function(jobs)
 		for k,v in ipairs(jobs) do
-			ESX.Jobs[v.name] = v
-			ESX.Jobs[v.name].grades = {}
+			Jobs[v.name] = v
+			Jobs[v.name].grades = {}
 		end
 
 		MySQL.Async.fetchAll('SELECT * FROM job_grades', {}, function(jobGrades)
 			for k,v in ipairs(jobGrades) do
-				if ESX.Jobs[v.job_name] then
-					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
+				if Jobs[v.job_name] then
+					Jobs[v.job_name].grades[tostring(v.grade)] = v
 				else
 					print(('[^3WARNING^7] Ignoring job grades for ^5"%s"^0 due to missing job'):format(v.job_name))
 				end
@@ -47,10 +48,11 @@ MySQL.ready(function()
 
 			for k2,v2 in pairs(ESX.Jobs) do
 				if ESX.Table.SizeOf(v2.grades) == 0 then
-					ESX.Jobs[v2.name] = nil
+					Jobs[v2.name] = nil
 					print(('[^3WARNING^7] Ignoring job ^5"%s"^0due to no job grades found'):format(v2.name))
 				end
 			end
+			ESX.Jobs = Jobs
 		end)
 	end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -234,13 +234,7 @@ ESX.GetPlayers = function()
 end
 
 ESX.GetExtendedPlayers = function()
-	local xPlayers = {}
-
-	for k,v in pairs(ESX.Players) do
-		xPlayers[k] = v
-	end
-
-	return xPlayers
+	return ESX.Players
 end
 
 ESX.GetPlayerFromId = function(source)

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -227,6 +227,16 @@ ESX.GetPlayers = function()
 	return sources
 end
 
+ESX.GetExtendedPlayers = function()
+	local xPlayers = {}
+
+	for k,v in pairs(ESX.Players) do
+		xPlayers[k] = v
+	end
+
+	return xPlayers
+end
+
 ESX.GetPlayerFromId = function(source)
 	return ESX.Players[tonumber(source)]
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -163,19 +163,25 @@ ESX.TriggerServerCallback = function(name, requestId, source, cb, ...)
 	end
 end
 
+local savePlayers = -1
+Citizen.CreateThread(function()
+	savePlayers = MySQL.Sync.store("UPDATE users SET ? WHERE ?")
+end)
+
 ESX.SavePlayer = function(xPlayer, cb)
 	local asyncTasks = {}
 
 	table.insert(asyncTasks, function(cb2)
-		MySQL.Async.execute('UPDATE users SET accounts = @accounts, job = @job, job_grade = @job_grade, `group` = @group, loadout = @loadout, position = @position, inventory = @inventory WHERE identifier = @identifier', {
-			['@accounts'] = json.encode(xPlayer.getAccounts(true)),
-			['@job'] = xPlayer.job.name,
-			['@job_grade'] = xPlayer.job.grade,
-			['@group'] = xPlayer.getGroup(),
-			['@loadout'] = json.encode(xPlayer.getLoadout(true)),
-			['@position'] = json.encode(xPlayer.getCoords()),
-			['@identifier'] = xPlayer.getIdentifier(),
-			['@inventory'] = json.encode(xPlayer.getInventory(true))
+		MySQL.Async.execute(savePlayers, {
+			{
+				['accounts'] = json.encode(xPlayer.getAccounts(true)),
+				['job'] = xPlayer.job.name,
+				['job_grade'] = xPlayer.job.grade,
+				['group'] = xPlayer.getGroup(),
+				['loadout'] = json.encode(xPlayer.getLoadout(true)),
+				['position'] = json.encode(xPlayer.getCoords()),
+				['inventory'] = json.encode(xPlayer.getInventory(true))
+			}, {['identifier'] = xPlayer.getIdentifier()}
 		}, function(rowsChanged)
 			cb2()
 		end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -3,51 +3,90 @@ Citizen.CreateThread(function()
 	SetGameType('ESX Roleplay')
 end)
 
+local awaitingRegistration = {}
 RegisterNetEvent('esx:onPlayerJoined')
-AddEventHandler('esx:onPlayerJoined', function()
-	if not ESX.Players[source] then
-		onPlayerJoined(source)
-	end
-end)
+if Config.Multichar then
+	AddEventHandler('esx_identity:completedRegistration', function(playerId, data)
+		awaitingRegistration[playerId] = data
+	end)
+	AddEventHandler('esx:onPlayerJoined', function(src, char, isNew)
+		if not ESX.Players[src] then
+			onPlayerJoined(src, char, isNew)
+		end
+	end)
+else
+	AddEventHandler('esx:onPlayerJoined', function()
+		if not ESX.Players[source] then
+			onPlayerJoined(source)
+		end
+	end)
+end
 
-function onPlayerJoined(playerId)
+function onPlayerJoined(playerId, char, isNew)
 	local identifier = ESX.GetIdentifier(playerId)
+	if char then identifier = 'char'..char..':'..identifier end
 
 	if identifier then
 		if ESX.GetPlayerFromIdentifier(identifier) then
 			DropPlayer(playerId, ('there was an error loading your character!\nError code: identifier-active-ingame\n\nThis error is caused by a player on this server who has the same identifier as you have. Make sure you are not playing on the same Rockstar account.\n\nYour Rockstar identifier: %s'):format(identifier))
+		elseif Config.Multichar and isNew then
+			createESXPlayer(identifier, playerId)
 		else
 			MySQL.Async.fetchScalar('SELECT 1 FROM users WHERE identifier = @identifier', {
 				['@identifier'] = identifier
 			}, function(result)
 				if result then
 					loadESXPlayer(identifier, playerId, false)
-				else
-					local accounts = {}
-
-					for account,money in pairs(Config.StartingAccountMoney) do
-						accounts[account] = money
-					end
-
-					if IsPlayerAceAllowed(playerId, "command") then
-						print(('^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
-						defaultGroup = "admin"
-					else
-						defaultGroup = "user"
-					end
-
-					MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`) VALUES (@accounts, @identifier, @group)', {
-						['@accounts'] = json.encode(accounts),
-						['@identifier'] = identifier,
-						['@group'] = defaultGroup
-					}, function(rowsChanged)
-						loadESXPlayer(identifier, playerId, true)
-					end)
-				end
+				else createESXPlayer(identifier, playerId) end
 			end)
 		end
 	else
 		DropPlayer(playerId, 'there was an error loading your character!\nError code: identifier-missing-ingame\n\nThe cause of this error is not known, your identifier could not be found. Please come back later or report this problem to the server administration team.')
+	end
+end
+
+function createESXPlayer(identifier, playerId)
+	local accounts = {}
+
+	for account,money in pairs(Config.StartingAccountMoney) do
+		accounts[account] = money
+	end
+
+	if IsPlayerAceAllowed(playerId, "command") then
+		print(('^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
+		defaultGroup = "admin"
+	else
+		defaultGroup = "user"
+	end
+
+	if not Config.Multichar then
+		MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`) VALUES (@accounts, @identifier, @group)', {
+			['@accounts'] = json.encode(accounts),
+			['@identifier'] = identifier,
+			['@group'] = defaultGroup
+		}, function(rowsChanged)
+			loadESXPlayer(identifier, playerId, true)
+		end)
+	else
+		local data
+		awaitingRegistration[playerId] = true
+		while true do
+			Citizen.Wait(250)
+			if awaitingRegistration[playerId] ~= true then data = awaitingRegistration[playerId] break end
+		end
+		awaitingRegistration[playerId] = nil
+		MySQL.Async.execute('INSERT INTO users (`accounts`, `identifier`, `group`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height`) VALUES (@accounts, @identifier, @group, @firstname, @lastname, @dateofbirth, @sex, @height)', {
+			['@accounts'] = json.encode(accounts),
+			['@identifier'] = identifier,
+			['@group'] = defaultGroup,
+			['@firstname'] = data.firstname,
+			['@lastname'] = data.lastname,
+			['@dateofbirth'] = data.dateofbirth,
+			['@sex'] = data.sex,
+			['@height'] = data.height,
+		}, function(rowsChanged)
+			loadESXPlayer(identifier, playerId, true)
+		end)
 	end
 end
 
@@ -81,7 +120,13 @@ function loadESXPlayer(identifier, playerId, isNew)
 	}
 
 	table.insert(tasks, function(cb)
-		MySQL.Async.fetchAll('SELECT accounts, job, job_grade, `group`, loadout, position, inventory FROM users WHERE identifier = @identifier', {
+		local query
+		if Config.Multichar then
+			query = 'SELECT `accounts`, `job`, `job_grade`, `group`, `loadout`, `position`, `inventory`, `skin`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height` FROM `users` WHERE identifier = @identifier'
+		else
+			query = 'SELECT `accounts`, `job`, `job_grade`, `group`, `loadout`, `position`, `inventory`, `skin` FROM `users` WHERE identifier = @identifier'
+		end
+		MySQL.Async.fetchAll(query, {
 			['@identifier'] = identifier
 		}, function(result)
 			local job, grade, jobObject, gradeObject = result[1].job, tostring(result[1].job_grade)
@@ -203,6 +248,25 @@ function loadESXPlayer(identifier, playerId, isNew)
 				userData.coords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
 			end
 
+			-- Skin
+			if result[1].skin and result[1].skin ~= '' then
+				userData.skin = json.decode(result[1].skin)
+			elseif userData.sex then
+				if userData.sex == 'f' then userData.skin = {sex=1} else userData.skin = {sex=0} end
+			end
+
+			-- Identity
+			if Config.Multichar then
+				if result[1].firstname and result[1].firstname ~= '' then
+					userData.firstname = result[1].firstname
+					userData.lastname = result[1].lastname
+					userData.playerName = userData.firstname..' '..userData.lastname
+					if result[1].dateofbirth then userData.dateofbirth = result[1].dateofbirth end
+					if result[1].sex then userData.sex = result[1].sex end
+					if result[1].height then userData.height = result[1].height end
+				end
+			end
+
 			cb()
 		end)
 	end)
@@ -210,6 +274,15 @@ function loadESXPlayer(identifier, playerId, isNew)
 	Async.parallel(tasks, function(results)
 		local xPlayer = CreateExtendedPlayer(playerId, identifier, userData.group, userData.accounts, userData.inventory, userData.weight, userData.job, userData.loadout, userData.playerName, userData.coords)
 		ESX.Players[playerId] = xPlayer
+
+		if Config.Multichar and userData.firstname then 
+			xPlayer.set('firstName', userData.firstname)
+			xPlayer.set('lastName', userData.lastname)
+			if userData.dateofbirth then xPlayer.set('dateofbirth', userData.dateofbirth) end
+			if userData.sex then xPlayer.set('sex', userData.sex) end
+			if userData.height then xPlayer.set('height', userData.height) end
+		end
+
 		TriggerEvent('esx:playerLoaded', playerId, xPlayer, isNew)
 
 		xPlayer.triggerEvent('esx:playerLoaded', {
@@ -220,7 +293,8 @@ function loadESXPlayer(identifier, playerId, isNew)
 			job = xPlayer.getJob(),
 			loadout = xPlayer.getLoadout(),
 			maxWeight = xPlayer.getMaxWeight(),
-			money = xPlayer.getMoney()
+			money = xPlayer.getMoney(),
+			skin = userData.skin
 		}, isNew)
 
 		xPlayer.triggerEvent('esx:createMissingPickups', ESX.Pickups)
@@ -249,6 +323,21 @@ AddEventHandler('playerDropped', function(reason)
 		end)
 	end
 end)
+
+if Config.Multichar then
+	AddEventHandler('esx:playerLogout', function(playerId)
+		local xPlayer = ESX.GetPlayerFromId(playerId)
+		awaitingRegistration[playerId] = nil
+		if xPlayer then
+			TriggerEvent('esx:playerDropped', playerId, reason)
+
+			ESX.SavePlayer(xPlayer, function()
+				ESX.Players[playerId] = nil
+			end)
+		end
+		TriggerClientEvent("esx:onPlayerLogout", playerId)
+	end)
+end
 
 RegisterNetEvent('esx:updateCoords')
 AddEventHandler('esx:updateCoords', function(coords)

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,7 +5,11 @@ Citizen.CreateThread(function()
 	MySQL.Async.store("INSERT INTO users SET ?", function(storeId)
 		NewPlayer = storeId
 	end)
-	MySQL.Async.store("SELECT `accounts`, `job`, `job_grade`, `group`, `position`, `inventory`, `skin`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height`, `is_dead` FROM `users` WHERE ?? LIKE ?", function(storeId)
+	
+	local query = '`accounts`, `job`, `job_grade`, `group`, `position`, `inventory`, `skin`'
+	if Config.Multichar or Config.Identity then query = query..', `firstname`, `lastname`, `dateofbirth`, `sex`, `height`' end
+
+	MySQL.Async.store("SELECT "..query.." FROM `users` WHERE ?? LIKE ?", function(storeId)
 		LoadPlayer = storeId
 	end)
 end)
@@ -268,13 +272,6 @@ function loadESXPlayer(identifier, playerId, isNew)
 				if result[1].sex then userData.sex = result[1].sex end
 				if result[1].height then userData.height = result[1].height end
 			end
-			
-			-- Death
-			if result[1].is_dead and result[1].is_dead ~= '' then
-				userData.is_dead = result[1].is_dead
-			else
-				userData.is_dead = 0
-			end
 
 			cb()
 		end)
@@ -303,7 +300,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 			loadout = xPlayer.getLoadout(),
 			maxWeight = xPlayer.getMaxWeight(),
 			money = xPlayer.getMoney(),
-			dead = userData.dead
+			dead = 0
 		}, isNew, userData.skin)
 
 		xPlayer.triggerEvent('esx:createMissingPickups', ESX.Pickups)
@@ -623,7 +620,7 @@ Citizen.CreateThread(
 								([[
 
 ^1----------------------------------------------------------------------
-^1URGENT: YOUR ES-EXTENDED IS OUTDATED!
+^1URGENT: YOUR ES_EXTENDED IS OUTDATED!
 ^1COMMIT UPDATE: ^5%s AVAILABLE
 ^1DOWNLOAD:^5 https://github.com/esx-framework/es_extended/tree/legacy
 ^1CHANGELOG:^5 %s
@@ -638,7 +635,7 @@ Citizen.CreateThread(
 								([[
 
 ^8-------------------------------------------------------
-^2Your Es-extended is the latest version!
+^2Your es_extended is the latest version!
 ^5Version:^0 %s
 ^5COMMIT:^0 %s
 ^5CHANGELOG:^0 %s
@@ -654,7 +651,7 @@ Citizen.CreateThread(
 						print(
 							([[
 ^1----------------------------------------------------------------------
-^1URGENT: YOUR ES-EXTENDED IS OUTDATATED!!!
+^1URGENT: YOUR ES_EXTENDED IS OUTDATATED!!!
 ^1COMMIT UPDATE: ^5%s AVAILABLE
 ^1DOWNLOAD:^5 https://github.com/esx-framework/es_extended/tree/legacy
 ^1CHANGELOG:^5 %s
@@ -666,7 +663,7 @@ Citizen.CreateThread(
 						)
 						end
 					else
-						print('[^1ERROR^0] Es-Extended unable to check version!')
+						print('[^1ERROR^0] es_extended unable to check version!')
 					end
 				end,
 				'GET'

--- a/server/main.lua
+++ b/server/main.lua
@@ -120,13 +120,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 	}
 
 	table.insert(tasks, function(cb)
-		local query
-		if Config.Multichar then
-			query = 'SELECT `accounts`, `job`, `job_grade`, `group`, `loadout`, `position`, `inventory`, `skin`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height` FROM `users` WHERE identifier = @identifier'
-		else
-			query = 'SELECT `accounts`, `job`, `job_grade`, `group`, `loadout`, `position`, `inventory`, `skin` FROM `users` WHERE identifier = @identifier'
-		end
-		MySQL.Async.fetchAll(query, {
+		MySQL.Async.fetchAll('SELECT `accounts`, `job`, `job_grade`, `group`, `loadout`, `position`, `inventory`, `skin`, `firstname`, `lastname`, `dateofbirth`, `sex`, `height` FROM `users` WHERE identifier = @identifier', {
 			['@identifier'] = identifier
 		}, function(result)
 			local job, grade, jobObject, gradeObject = result[1].job, tostring(result[1].job_grade)
@@ -256,15 +250,13 @@ function loadESXPlayer(identifier, playerId, isNew)
 			end
 
 			-- Identity
-			if Config.Multichar then
-				if result[1].firstname and result[1].firstname ~= '' then
-					userData.firstname = result[1].firstname
-					userData.lastname = result[1].lastname
-					userData.playerName = userData.firstname..' '..userData.lastname
-					if result[1].dateofbirth then userData.dateofbirth = result[1].dateofbirth end
-					if result[1].sex then userData.sex = result[1].sex end
-					if result[1].height then userData.height = result[1].height end
-				end
+			if result[1].firstname and result[1].firstname ~= '' then
+				userData.firstname = result[1].firstname
+				userData.lastname = result[1].lastname
+				userData.playerName = userData.firstname..' '..userData.lastname
+				if result[1].dateofbirth then userData.dateofbirth = result[1].dateofbirth end
+				if result[1].sex then userData.sex = result[1].sex end
+				if result[1].height then userData.height = result[1].height end
 			end
 
 			cb()
@@ -275,7 +267,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 		local xPlayer = CreateExtendedPlayer(playerId, identifier, userData.group, userData.accounts, userData.inventory, userData.weight, userData.job, userData.loadout, userData.playerName, userData.coords)
 		ESX.Players[playerId] = xPlayer
 
-		if Config.Multichar and userData.firstname then 
+		if userData.firstname then 
 			xPlayer.set('firstName', userData.firstname)
 			xPlayer.set('lastName', userData.lastname)
 			if userData.dateofbirth then xPlayer.set('dateofbirth', userData.dateofbirth) end

--- a/server/main.lua
+++ b/server/main.lua
@@ -132,7 +132,6 @@ function loadESXPlayer(identifier, playerId, isNew)
 
 	table.insert(tasks, function(cb)
 		MySQL.Async.fetchAll(LoadPlayer, {'identifier', {identifier}
-			['@identifier'] = identifier
 		}, function(result)
 			local job, grade, jobObject, gradeObject = result[1].job, tostring(result[1].job_grade)
 			local foundAccounts, foundItems = {}, {}

--- a/server/main.lua
+++ b/server/main.lua
@@ -304,9 +304,8 @@ function loadESXPlayer(identifier, playerId, isNew)
 			loadout = xPlayer.getLoadout(),
 			maxWeight = xPlayer.getMaxWeight(),
 			money = xPlayer.getMoney(),
-			skin = userData.skin,
 			dead = userData.dead
-		}, isNew)
+		}, isNew, userData.skin)
 
 		xPlayer.triggerEvent('esx:createMissingPickups', ESX.Pickups)
 		xPlayer.triggerEvent('esx:registerSuggestions', ESX.RegisteredCommands)

--- a/server/main.lua
+++ b/server/main.lua
@@ -251,7 +251,7 @@ function loadESXPlayer(identifier, playerId, isNew)
 			-- Skin
 			if result[1].skin and result[1].skin ~= '' then
 				userData.skin = json.decode(result[1].skin)
-			elseif userData.sex then
+			else
 				if userData.sex == 'f' then userData.skin = {sex=1} else userData.skin = {sex=0} end
 			end
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
 	"version": "legacy",
-	"commit" : "1.2.0",
-	"changelog": "Preserve compatibility for getting hashes; store player ped and death in PlayerData; resolve typos and outdated prints"
+	"commit" : "1.3.0",
+	"changelog": "Multicharacter support; improved spawning and skin loading; minor fixes and optimisation"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
 	"version": "legacy",
-	"commit" : "1.3.0",
-	"changelog": "Multicharacter support; improved spawning and skin loading; minor fixes and optimisation"
+	"commit" : "1.3.1",
+	"changelog": "\n- Improved spawn event triggers\n- Improved support for relogging\n- Set PlayerData.dead initial value based on `is_dead` column (or 0)\n- Added a MySQL.store for the loadESXPlayer function\n- Ammo sync now waits for the player to stop shooting before sending a server event\n- /clearloadout now clears all player weapons on the first try\n- Minor fixes and optimisations"
 }


### PR DESCRIPTION
Pending review and approval by Taso.  
I currently have people in my Discord testing with these changes (with and without multicharacter enabled).
No reported issues when disabled; minor issues with the multicharacter itself are being patched when reported.

Requires pull requests for esx_skin and esx_identity for the multicharacter itself to work properly (minor edits, retains compatibility).

## Proposed Changes

	- Toggle multicharacter support through the config
	- Modify playerLoaded client event to trigger to support different spawning method based on multichar setting
	- Set a player variable for checking raw license instead of identifier
	- Move the creation of an ESXPlayer into its own function
	- When using multicharacter, retrieve values from ESX identity and set them when loading the player
	- Support for logging the player out (relog system is incomplete, but separate)
	- Fade the screen to black immediately when player joins (and is not using multichar)
	- Load the player skin initially instead of loading the player and triggering a callback for skin data
	- Create a temporary table to store Jobs in before Grades have been retrieved, then set ESX.Jobs
	
## More changes

	- Load and set player identity data if it exists
	- Added a function to retrieve all xPlayer data (instead of just sources)
	- Spawnmanager is now a dependency
	- Removed the wait after triggering spawnmanager and moved the events into the callback
	- Fixed scaling for DrawText3D
	- Removed the rectangle from DrawText3D (it was recently added and does not scale well with distance, font, and size)
	- Added a new function to clear the HUD (instead of sending multiple NUI messages to clear each one)
	- Removed the `sv_restart` command
	- Added a stored query for creating players