### PR TITLE
Legacy - Fix non-networked objects/vehicles; send full MySQL.store queries; improve multichar support and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ To get an idea for how you can utilise imports and the new functions, you can re
 
 ## Conflicts
 * The following resources should not be used with ESX Legacy and can result in errors
+	- **essentialsmode**
 	- basic-gamemode
 	- fivem-map-skater
 	- fivem-map-hipster
-	- **essentialsmode**
+	- default_spawnpoint
 
 
 ## 1.2 + Features

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -335,11 +335,10 @@ ESX.Game.Teleport = function(entity, coords, cb)
 	end
 end
 
-ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
+ESX.Game.SpawnObject = function(object, coords, cb, networked)
 	local model = (type(object) == 'number' and model or GetHashKey(object))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked == nil and true or false
-	dynamic = dynamic ~= nil and true or false
+	networked = networked or true
 
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
@@ -347,7 +346,7 @@ ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
 		-- The below has to be done just for CreateObject since for some reason CreateObjects model argument is set
 		-- as an Object instead of a hash so it doesn't automatically hash the item
 		model = type(model) == 'number' and model or GetHashKey(model)
-		local obj = CreateObject(model, vector.xyz, networked, false, dynamic)
+		local obj = CreateObject(model, vector.xyz, networked, false, true)
 		if cb then
 			cb(obj)
 		end
@@ -372,7 +371,7 @@ end
 ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked == nil and true or false
+	networked = networked or true
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -17,7 +17,6 @@ AddEventHandler('esx:playerLoaded', function(playerData, isNew, skin)
 	FreezeEntityPosition(PlayerPedId(), true)
 
 	if Config.Multichar then
-		TriggerEvent('esx_multicharacter:SpawnCharacter', playerData.coords, isNew)
 		Citizen.Wait(3000)
 	else
 		exports.spawnmanager:spawnPlayer({
@@ -85,13 +84,13 @@ AddEventHandler('esx:setMaxWeight', function(newMaxWeight) ESX.PlayerData.maxWei
 AddEventHandler('esx:onPlayerSpawn', function()
 	local playerPed = PlayerPedId()
 	if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
-	ESX.SetPlayerData('dead', false)
+	if ESX.PlayerData.dead ~= false then ESX.SetPlayerData('dead', false) end
 end)
 
 AddEventHandler('esx:onPlayerDeath', function()
 	local playerPed = PlayerPedId()
 	if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
-	ESX.SetPlayerData('dead', true)
+	if ESX.PlayerData.dead ~= false then ESX.SetPlayerData('dead', true) end
 end)
 
 AddEventHandler('skinchanger:modelLoaded', function()
@@ -186,9 +185,6 @@ end)
 
 RegisterNetEvent('esx:addWeapon')
 AddEventHandler('esx:addWeapon', function(weapon, ammo)
-	-- Removed ESX.PlayerData.ped from being stored in a variable, not needed
-	-- when it's only being used once, also doing it in a few
-	-- functions below this one
 	GiveWeaponToPed(ESX.PlayerData.ped, GetHashKey(weapon), ammo, false, false)
 end)
 
@@ -406,7 +402,6 @@ function StartServerSyncLoops()
 		local previousCoords = vector3(ESX.PlayerData.coords.x, ESX.PlayerData.coords.y, ESX.PlayerData.coords.z)
 
 		while ESX.PlayerLoaded do
-			Citizen.Wait(1500)
 			local playerPed = PlayerPedId()
 			if ESX.PlayerData.ped ~= playerPed then ESX.SetPlayerData('ped', playerPed) end
 
@@ -421,6 +416,7 @@ function StartServerSyncLoops()
 					TriggerServerEvent('esx:updateCoords', formattedCoords)
 				end
 			end
+			Citizen.Wait(1500)
 		end
 	end)
 end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -165,7 +165,7 @@ end
 
 local savePlayers = -1
 Citizen.CreateThread(function()
-	savePlayers = MySQL.Sync.store("UPDATE users SET ? WHERE ?")
+	savePlayers = MySQL.Sync.store("UPDATE users SET `accounts` = ?, `job` = ?, `job_grade` = ?, `group` = ?, `position`= ?, `inventory`, = ?, `loadout` = ? WHERE `identifier` = ?")
 end)
 
 ESX.SavePlayer = function(xPlayer, cb)
@@ -173,15 +173,14 @@ ESX.SavePlayer = function(xPlayer, cb)
 
 	table.insert(asyncTasks, function(cb2)
 		MySQL.Async.execute(savePlayers, {
-			{
-				['accounts'] = json.encode(xPlayer.getAccounts(true)),
-				['job'] = xPlayer.job.name,
-				['job_grade'] = xPlayer.job.grade,
-				['group'] = xPlayer.getGroup(),
-				['loadout'] = json.encode(xPlayer.getLoadout(true)),
-				['position'] = json.encode(xPlayer.getCoords()),
-				['inventory'] = json.encode(xPlayer.getInventory(true))
-			}, {['identifier'] = xPlayer.getIdentifier()}
+			json.encode(xPlayer.getAccounts(true)),
+			xPlayer.job.name,
+			xPlayer.job.grade,
+			xPlayer.getGroup(),
+			json.encode(xPlayer.getCoords()),
+			json.encode(xPlayer.getInventory(true)),
+			json.encode(xPlayer.getLoadout(true)),
+			xPlayer.getIdentifier()
 		}, function(rowsChanged)
 			cb2()
 		end)
@@ -251,7 +250,7 @@ end
 
 ESX.GetIdentifier = function(playerId)
 	for k,v in ipairs(GetPlayerIdentifiers(playerId)) do
-		if string.match(v, 'license') then
+		if string.match(v, 'license:') then
 			local identifier = string.gsub(v, 'license:', '')
 			return identifier
 		end

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
 	"version": "legacy",
-	"commit" : "1.3.2",
-	"changelog": "Corrected a mistake resulting in loadouts not being loaded with players"
+	"commit" : "1.3.3",
+	"changelog": "\n- Resolved an issue when using Config.Identity\n- MySQL.store is now storing entire queries ahead of time\n- Improved support when using esx_multicharacter"
 }


### PR DESCRIPTION
> Reapplied the changes from my last PR due to accidentally merging the incorrect branch.

I had the multicharacter send an event to ESX and a while loop running, waiting for identity registration to complete. That code has been removed, improved, and implemented outside the framework.

MySQL.store now stores the full queries, waiting just for the statements to be received.

Fixed an issue with player sex being set incorrectly, no longer updating ESX.PlayerData.dead state if the value does not change.