### PR TITLE
fix(client/functions): Spawn networked and local entities correctly

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -335,11 +335,10 @@ ESX.Game.Teleport = function(entity, coords, cb)
 	end
 end
 
-ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
+ESX.Game.SpawnObject = function(object, coords, cb, networked)
 	local model = (type(object) == 'number' and model or GetHashKey(object))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked == nil and true or false
-	dynamic = dynamic ~= nil and true or false
+	networked = networked == nil and true or networked
 
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
@@ -347,7 +346,7 @@ ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
 		-- The below has to be done just for CreateObject since for some reason CreateObjects model argument is set
 		-- as an Object instead of a hash so it doesn't automatically hash the item
 		model = type(model) == 'number' and model or GetHashKey(model)
-		local obj = CreateObject(model, vector.xyz, networked, false, dynamic)
+		local obj = CreateObject(model, vector.xyz, networked, false, true)
 		if cb then
 			cb(obj)
 		end
@@ -372,7 +371,7 @@ end
 ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked == nil and true or false
+	networked = networked == nil and true or networked
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -335,10 +335,11 @@ ESX.Game.Teleport = function(entity, coords, cb)
 	end
 end
 
-ESX.Game.SpawnObject = function(object, coords, cb, networked)
+ESX.Game.SpawnObject = function(object, coords, cb, networked, dynamic)
 	local model = (type(object) == 'number' and model or GetHashKey(object))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked or true
+	networked = networked == nil and true or false
+	dynamic = dynamic ~= nil and true or false
 
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
@@ -346,7 +347,7 @@ ESX.Game.SpawnObject = function(object, coords, cb, networked)
 		-- The below has to be done just for CreateObject since for some reason CreateObjects model argument is set
 		-- as an Object instead of a hash so it doesn't automatically hash the item
 		model = type(model) == 'number' and model or GetHashKey(model)
-		local obj = CreateObject(model, vector.xyz, networked, false, true)
+		local obj = CreateObject(model, vector.xyz, networked, false, dynamic)
 		if cb then
 			cb(obj)
 		end
@@ -371,7 +372,7 @@ end
 ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
-	networked = networked or true
+	networked = networked == nil and true or false
 	Citizen.CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
 	"version": "legacy",
-	"commit" : "1.3.3",
-	"changelog": "\n- Resolved an issue when using Config.Identity\n- MySQL.store is now storing entire queries ahead of time\n- Improved support when using esx_multicharacter"
+	"commit" : "1.3.4",
+	"changelog": "\n- Corrected spawning of entities"
 }


### PR DESCRIPTION
When the functions for local and networked entities were merged, if networked was defined it would always return false.
My initial "fix" resulted in local vehicles spawning as networked 😰 - this corrects both issues.