### PR TITLE
Optimised player save data function

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -196,21 +196,51 @@ ESX.SavePlayer = function(xPlayer, cb)
 end
 
 ESX.SavePlayers = function(cb)
-	local xPlayers, asyncTasks = ESX.GetPlayers(), {}
+	local xPlayers = ESX.GetPlayers()
+	print("ESX.GetPlayers executed in es_extended saveplayers")
 
-	for i=1, #xPlayers, 1 do
-		table.insert(asyncTasks, function(cb2)
-			local xPlayer = ESX.GetPlayerFromId(xPlayers[i])
-			ESX.SavePlayer(xPlayer, cb2)
-		end)
+	local selectListWithNames = "SELECT '%s' AS identifier, '%s' AS new_accounts, '%s' AS new_job, %s AS new_job_grade, '%s' AS new_group, '%s' AS new_loadout, '%s' AS new_position, '%s' AS new_inventory "
+	local selectListNoNames = "SELECT '%s', '%s', '%s' , %s, '%s', '%s', '%s', '%s' "
+
+	if #xPlayers > 0 then
+		local updateCommand = 'UPDATE users u JOIN ('
+
+		local selectList = selectListNoNames
+		local first = true
+		for k, player in pairs(xPlayers) do
+			local xPlayer = ESX.GetPlayerFromId(player)
+			if first == false then
+				updateCommand = updateCommand .. ' UNION '
+			else
+				selectList = selectListWithNames
+			end
+
+			updateCommand = updateCommand .. string.format(selectList,
+				xPlayer.identifier,
+				json.encode(xPlayer.getAccounts(true)),
+				xPlayer.job.name,
+				xPlayer.job.grade,
+				xPlayer.getGroup(),
+				json.encode(xPlayer.getLoadout(true)),
+				json.encode(xPlayer.getCoords()),
+				json.encode(xPlayer.getInventory(true))
+			)
+	
+			first = false
+		end
+
+		updateCommand = updateCommand .. ' ) vals ON u.identifier = vals.identifier SET accounts = new_accounts, job = new_job, job_grade = new_job_grade, `group` = new_group, loadout = new_loadout, `position` = new_position, inventory = new_inventory'
+
+		MySQL.Async.execute(updateCommand)
+
+		print(('[es_extended] [^2INFO^7] Saved %s player(s)'):format(#xPlayers))
+
 	end
 
-	Async.parallelLimit(asyncTasks, 8, function(results)
-		print(('[^2INFO^7] Saved ^5%s^0 player(s)'):format(#xPlayers))
-		if cb then
-			cb()
-		end
-	end)
+	if cb then
+		cb()
+	end
+
 end
 
 ESX.StartDBSync = function()


### PR DESCRIPTION
This addresses the original issue on v1-Final where whilst there was async updates being done, the async list of tasks to run only had a single task anyway so all update statements were still being done one by one. I thought my take on the solution might still be of value on the legacy branch. Rather the run a stack of UPDATE statements which still requires multiple calls across process to MySQL/MariaDB and potentially across the wire if they're not on the same server, then just do a single UPDATE statement for everyone in one step. This is achieved as a set operation across UNIONed SELECT statements representing the value of each column being updated for each player. I've used this approach a couple of times in ESX resources and thread hitches stopped. This level of efficiency takes things to a level where you could save more often without having an adverse effect of the server. You do end up with a larger query to be exexuted but as a "set operation" this is better overall than 64+ individual UPDATE statements being made.